### PR TITLE
Added code actions for functions and methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,16 @@
       "title": "CodeMaker AI",
       "properties": {
         "codemaker.apiKey": {
-          "type": "string",
-          "description": "API Key"
+          "description": "API Key",
+          "type": "string"          
         },
-        "codemaker.disableAutocomplete": {
+        "codemaker.enableAutocomplete": {
+          "description": "Enables autocompletion.",
+          "type": "boolean",
+          "default": false
+        },
+        "codemaker.enableCodeActions": {          
+          "description": "Enables code actions",
           "type": "boolean",
           "default": true
         }
@@ -112,6 +118,14 @@
       {
         "command": "extension.ai.codemaker.replace.code",
         "title": "Code"
+      },
+      {
+        "command": "extension.ai.codemaker.replace.method.code",
+        "title": "Replace code"
+      },
+      {
+        "command": "extension.ai.codemaker.replace.method.doc",
+        "title": "Replace documentation"
       }
     ]
   },

--- a/src/completion/completionProvider.ts
+++ b/src/completion/completionProvider.ts
@@ -1,3 +1,5 @@
+// Copyright 2023 CodeMaker AI Inc. All rights reserved.
+
 import * as vscode from 'vscode';
 import CodemakerService from '../service/codemakerService';
 import {    
@@ -63,16 +65,10 @@ export default class CompletionProvider implements vscode.InlineCompletionItemPr
     }
 
     private shouldSkip(document: vscode.TextDocument, position: vscode.Position): boolean {
-
-        const autocompleteDisabled = vscode.workspace.getConfiguration().get('codemaker.disableAutocomplete') as boolean;
-
-        if (autocompleteDisabled
+        const isAutocompleEnabled = vscode.workspace.getConfiguration().get('codemaker.enableAutocomplete') as boolean;
+        return !isAutocompleEnabled
             || !checkLineLength(position)
-            || !isEndOfLine(document, position)) {
-
-            return true;
-        }
-        return false;
+            || !isEndOfLine(document, position);
     }
 
     private shouldInvokeCompletion(currLineBeforeCursor: string) {

--- a/src/completion/completionProvider.ts
+++ b/src/completion/completionProvider.ts
@@ -9,6 +9,7 @@ import {
     checkLineLength,
     isEndOfLine
 } from '../utils/editorUtils';
+import { Configuration } from '../configuration/configuration';
 
 export default class CompletionProvider implements vscode.InlineCompletionItemProvider {
 
@@ -65,8 +66,7 @@ export default class CompletionProvider implements vscode.InlineCompletionItemPr
     }
 
     private shouldSkip(document: vscode.TextDocument, position: vscode.Position): boolean {
-        const isAutocompleEnabled = vscode.workspace.getConfiguration().get('codemaker.enableAutocomplete') as boolean;
-        return !isAutocompleEnabled
+        return !Configuration.isAutoCompleteEnabled()
             || !checkLineLength(position)
             || !isEndOfLine(document, position);
     }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,0 +1,22 @@
+// Copyright 2023 CodeMaker AI Inc. All rights reserved.
+
+import * as vscode from 'vscode';
+
+export class Configuration {
+
+    static apiKey(): string {
+        return this.get('codemaker.apiKey');
+    }
+
+    static isAutoCompleteEnabled(): boolean {
+        return this.get('codemaker.enableAutocomplete');
+    }
+
+    static isCodeActionsEnabled(): boolean {
+        return this.get('codemaker.enableCodeActions');
+    }
+
+    private static get<T>(key: string): T {
+        return vscode.workspace.getConfiguration().get(key) as T;
+    }
+}

--- a/src/diagnostics/codePathDiagnostics.ts
+++ b/src/diagnostics/codePathDiagnostics.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Configuration } from '..//configuration/configuration';
 import { isFileSupported } from '../utils/languageUtils';
 
-export const CODE_PATH = 'code_path';
+export const CODE_PATH = 'codemkaker.codepath';
 
 export async function refreshDiagnostics(document: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection) {
     if (!Configuration.isCodeActionsEnabled()) {

--- a/src/diagnostics/codePathDiagnostics.ts
+++ b/src/diagnostics/codePathDiagnostics.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+import { isFileSupported } from '../utils/languageUtils';
+
+export const CODE_PATH = 'code_path';
+
+export async function refreshDiagnostics(document: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection) {
+    const isCodeActionsEnabled = vscode.workspace.getConfiguration().get('codemaker.enableCodeActions') as boolean;
+    if (!isCodeActionsEnabled) {
+        return;
+    }
+
+    if (!isFileSupported(document.fileName)) {
+        return;
+    }
+
+    const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        document.uri
+    );
+
+    if (!symbols) {
+        return;
+    }
+
+    const diagnostics: vscode.Diagnostic[] = [];
+    for (let symbol of symbols) {
+        if (symbol.kind == vscode.SymbolKind.Function) {
+            diagnostics.push(createDiagnostic(symbol.range, 'Function'));
+        } else if (symbol.kind == vscode.SymbolKind.Class) {
+            if (!symbol.children) {
+                return;
+            }
+            for (let child of symbol.children) {
+                if (child.kind == vscode.SymbolKind.Method) {                    
+                    diagnostics.push(createDiagnostic(child.range, 'Method'));
+                }
+            }
+        }
+    }
+    diagnosticCollection.set(document.uri, diagnostics);
+}
+
+export function subscribeToDocumentChanges(context: vscode.ExtensionContext, diagnosticsCollection: vscode.DiagnosticCollection): void {
+    if (vscode.window.activeTextEditor) {
+        refreshDiagnostics(vscode.window.activeTextEditor.document, diagnosticsCollection);
+    }
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor(editor => {
+            if (editor) {
+                refreshDiagnostics(editor.document, diagnosticsCollection);
+            }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument(e => refreshDiagnostics(e.document, diagnosticsCollection))
+    );
+
+    context.subscriptions.push(
+        vscode.workspace.onDidCloseTextDocument(doc => diagnosticsCollection.delete(doc.uri))
+    );
+
+}
+
+function createDiagnostic(range: vscode.Range, title: string) {
+    const diagnostic = new vscode.Diagnostic(range, title, vscode.DiagnosticSeverity.Hint);
+    diagnostic.code = CODE_PATH;
+    return diagnostic;
+}

--- a/src/diagnostics/codePathDiagnostics.ts
+++ b/src/diagnostics/codePathDiagnostics.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
+import { Configuration } from '..//configuration/configuration';
 import { isFileSupported } from '../utils/languageUtils';
 
 export const CODE_PATH = 'code_path';
 
 export async function refreshDiagnostics(document: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection) {
-    const isCodeActionsEnabled = vscode.workspace.getConfiguration().get('codemaker.enableCodeActions') as boolean;
-    if (!isCodeActionsEnabled) {
+    if (!Configuration.isCodeActionsEnabled()) {
         return;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { AuthenticationError, UnsupportedLanguageError } from './sdk/errors';
 import CompletionProvider from './completion/completionProvider';
 import { findCodePath } from './utils/codePathUtils';
 import { CODE_PATH, subscribeToDocumentChanges } from './diagnostics/codePathDiagnostics';
+import { Configuration } from './configuration/configuration';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -17,7 +18,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "CodeMaker" is now active!');
 
-	const apiKey = vscode.workspace.getConfiguration().get('codemaker.apiKey') as string;
+	const apiKey = Configuration.apiKey()
 	const codemakerService = new CodemakerService(apiKey);
 
 	registerDiagnostics(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import * as vscode from 'vscode';
 import CodemakerService from './service/codemakerService';
 import { AuthenticationError, UnsupportedLanguageError } from './sdk/errors';
 import CompletionProvider from './completion/completionProvider';
+import { findCodePath } from './utils/codePathUtils';
+import { CODE_PATH, subscribeToDocumentChanges } from './diagnostics/codePathDiagnostics';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -15,11 +17,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "CodeMaker" is now active!');
 
-	const token = vscode.workspace.getConfiguration().get('codemaker.apiKey') as string;
-	const codemakerService = new CodemakerService(token);
-	
+	const apiKey = vscode.workspace.getConfiguration().get('codemaker.apiKey') as string;
+	const codemakerService = new CodemakerService(apiKey);
+
+	registerDiagnostics(context);
 	registerActions(context, codemakerService);
 	registerCompletionProvider(context, codemakerService);
+	registerCodeAction(context, codemakerService);	
 }
 
 // This method is called when your extension is deactivated
@@ -34,6 +38,12 @@ function errorHandler(action: string, err: any) {
 		console.error(err);
 		vscode.window.showInformationMessage(`${action} failed`);
 	}
+}
+
+function registerDiagnostics(context: vscode.ExtensionContext) {
+	const diagnosticColection = vscode.languages.createDiagnosticCollection("ai.codemaker.codepath");
+	context.subscriptions.push(diagnosticColection);
+	subscribeToDocumentChanges(context, diagnosticColection);
 }
 
 function registerActions(context: vscode.ExtensionContext, codemakerService: CodemakerService) {
@@ -80,6 +90,46 @@ function registerActions(context: vscode.ExtensionContext, codemakerService: Cod
 				.catch(err => errorHandler("Code replacement", err));
 		}
 	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('extension.ai.codemaker.replace.method.doc', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			return;
+		}
+		const uri = editor.document.uri;
+		const codePath = await findCodePath(uri, editor.selection.active)
+		if (!codePath) {
+			return null;
+		}
+
+		vscode.window.showInformationMessage(`Replacing documentation for ${uri ? uri.path : 'null'}`);
+
+		codemakerService.replaceDocumentation(vscode.Uri.parse(uri.path), codePath)
+			.then(() => {
+				vscode.window.showInformationMessage(`Documentation replaced for ${uri ? uri.path : 'null'}`);
+			})
+			.catch(err => errorHandler("Documentation replacement", err));
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('extension.ai.codemaker.replace.method.code', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			return;
+		}
+		const uri = editor.document.uri;
+		const codePath = await findCodePath(uri, editor.selection.active)
+		if (!codePath) {
+			return null;
+		}
+
+		vscode.window.showInformationMessage(`Replacing code for ${uri ? uri.path : 'null'}`);
+
+		codemakerService.replaceCode(vscode.Uri.parse(uri.path), codePath)
+			.then(() => {
+				vscode.window.showInformationMessage(`Code replaced for ${uri ? uri.path : 'null'}`);
+			})
+			.catch(err => errorHandler("Code replacement", err));
+	}));
 }
 
 function registerCompletionProvider(context: vscode.ExtensionContext, service: CodemakerService) {
@@ -87,4 +137,54 @@ function registerCompletionProvider(context: vscode.ExtensionContext, service: C
 	context.subscriptions.push(
 		vscode.languages.registerInlineCompletionItemProvider({ pattern: '**' }, provider)
 	);
+}
+
+function registerCodeAction(context: vscode.ExtensionContext, service: CodemakerService) {
+	context.subscriptions.push(
+		vscode.languages.registerCodeActionsProvider('*', new ReplaceMethodCodeAction(), {
+			providedCodeActionKinds: ReplaceMethodCodeAction.providedCodeActionKinds
+		})
+	);
+	context.subscriptions.push(
+		vscode.languages.registerCodeActionsProvider('*', new ReplaceMethodDocumentationAction(), {
+			providedCodeActionKinds: ReplaceMethodDocumentationAction.providedCodeActionKinds
+		})
+	);
+}
+
+export class ReplaceMethodCodeAction implements vscode.CodeActionProvider {
+
+	public static readonly providedCodeActionKinds = [
+		vscode.CodeActionKind.QuickFix
+	];
+
+	provideCodeActions(document: vscode.TextDocument, selection: vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken) {
+		return context.diagnostics
+			.filter(diagnostic => diagnostic.code === CODE_PATH).map(diagnostic => this.createCommand(diagnostic));
+	}
+
+	createCommand(diagnostic: vscode.Diagnostic) {
+		const action = new vscode.CodeAction('Replace code', vscode.CodeActionKind.QuickFix);
+		action.command = { command: 'extension.ai.codemaker.replace.method.code', title: 'Replaces code', tooltip: 'This will replace code.' };
+		action.isPreferred = true;
+		return action;
+	}
+}
+
+export class ReplaceMethodDocumentationAction implements vscode.CodeActionProvider {
+
+	public static readonly providedCodeActionKinds = [
+		vscode.CodeActionKind.QuickFix
+	];
+
+	async provideCodeActions(document: vscode.TextDocument, selection: vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken) {
+		return context.diagnostics
+			.filter(diagnostic => diagnostic.code === CODE_PATH).map(diagnostic => this.createCommand(diagnostic));
+	}
+
+	createCommand(diagnostic: vscode.Diagnostic) {
+		const action = new vscode.CodeAction('Replace documentation', vscode.CodeActionKind.QuickFix);
+		action.command = { command: 'extension.ai.codemaker.replace.method.doc', title: 'Replaces documentation', tooltip: 'This will replace documentation.' };		
+		return action;
+	}
 }

--- a/src/utils/codePathUtils.ts
+++ b/src/utils/codePathUtils.ts
@@ -1,0 +1,38 @@
+// Copyright 2023 CodeMaker AI Inc. All rights reserved.
+
+import * as vscode from 'vscode';
+
+export async function findCodePath(uri: vscode.Uri, position: vscode.Position) {
+    const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        uri
+    );
+
+    if (!symbols) {
+        return;
+    }
+
+    for (let symbol of symbols) {
+        if (symbol.range.contains(position)) {
+            if (symbol.kind == vscode.SymbolKind.Function) {                
+                const name = callableSignature(symbol.name);                
+                return name;
+            } else if (symbol.kind == vscode.SymbolKind.Class) {
+                if (!symbol.children) {
+                    return;
+                }
+                for (let child of symbol.children) {
+                    if (child.range.contains(position) && child.kind == vscode.SymbolKind.Method) {
+                        const name = callableSignature(child.name);
+                        return `${symbol.name}.${name}`;
+                    }
+                }
+            }
+        }
+    }
+    return;
+}
+
+function callableSignature(name: string) {
+    return name.replace(/\(.*\)/, '(*)');
+}

--- a/src/utils/editorUtils.ts
+++ b/src/utils/editorUtils.ts
@@ -1,3 +1,5 @@
+// Copyright 2023 CodeMaker AI Inc. All rights reserved.
+
 import * as vscode from 'vscode';
 
 const minimumLineLength: number = 5;

--- a/src/utils/languageUtils.ts
+++ b/src/utils/languageUtils.ts
@@ -1,20 +1,29 @@
+// Copyright 2023 CodeMaker AI Inc. All rights reserved.
+
 import { Language } from '../sdk/model/model';
 import { UnsupportedLanguageError } from '../sdk/errors';
 
+const languages = new Map<string, Language>([
+    ["java", Language.java],
+    ["js", Language.javascript],
+    ["jsx", Language.javascript],
+    ["kt", Language.kotlin],
+    ["go", Language.go],
+])
+
+export function isFileSupported(fileName: string): boolean {
+    const ext = fileName.split('.').pop();
+    return !!ext && languages.has(ext);
+}
+
 export function langFromFileExtension(fileName: string): Language {
     const ext = fileName.split('.').pop();
-    switch (ext) {
-        case 'java':
-            return Language.java;
-        case 'js':
-        case 'jsx':
-            return Language.javascript;
-        case 'kt':
-            return Language.kotlin;
-        case 'go':
-            return Language.go;
-        default:
-            console.info("unsupported language: " + ext);
-            throw new UnsupportedLanguageError(ext);
+    if (!ext) {
+        throw new UnsupportedLanguageError("Could not determine file language " + fileName);
     }
+    const language = languages.get(ext);
+    if (!language) {
+        throw new UnsupportedLanguageError("Language is not supported for file with extension " + ext);
+    }
+    return language;
 }


### PR DESCRIPTION
Adds convenient contextual operations like

* Replace code
* Replace documentation 

That can be triggered for a function or a method.

This feature can be turn of from settings and is only supported for officially supported languages.