### PR TITLE
Added inline code generation command

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,16 @@
       {
         "command": "extension.ai.codemaker.replace.method.doc",
         "title": "Replace documentation"
+      },
+      {
+        "command": "extension.ai.codemaker.generate.inline.code",
+        "title": "Inline code"
+      }
+    ],
+    "keybindings":[
+      {
+        "command": "extension.ai.codemaker.generate.inline.code",
+        "key": "shift+ctrl+enter"
       }
     ]
   },

--- a/src/sdk/model/model.ts
+++ b/src/sdk/model/model.ts
@@ -44,6 +44,7 @@ export type Options = {
 
 export enum Mode {
     code = "CODE",
+    inlineCode = "INLINE_CODE",
     document = "DOCUMENT",
     unitTest = "UNIT_TEST",
     migrateSyntax = "MIGRATE_SYNTAX",

--- a/src/service/codemakerService.ts
+++ b/src/service/codemakerService.ts
@@ -23,15 +23,6 @@ class CodemakerService {
     }
 
     /**
-     * Generate documentation for given source files.
-     *
-     * @param path file or directory path.
-     */
-    public async generateDocumentation(path: vscode.Uri) {
-        return this.walkFiles(path, this.getFileProcessor(Mode.document));
-    }
-
-    /**
      * Generate code for given source files.
      *
      * @param path file or directory path.
@@ -41,7 +32,25 @@ class CodemakerService {
     }
 
     /**
-     * Generate code for given source files.
+     * Generate inline code for given source files.
+     *
+     * @param path file or directory path.
+     */
+    public async generateInlineCode(path: vscode.Uri, codePath: string) {
+        return this.walkFiles(path, this.getFileProcessor(Mode.inlineCode, Modify.none, codePath));
+    }
+
+    /**
+     * Generate documentation for given source files.
+     *
+     * @param path file or directory path.
+     */
+    public async generateDocumentation(path: vscode.Uri) {
+        return this.walkFiles(path, this.getFileProcessor(Mode.document));
+    }
+
+    /**
+     * Triggers predictive code generation for given source files.
      *
      * @param path file or directory path.
      */

--- a/src/utils/editorUtils.ts
+++ b/src/utils/editorUtils.ts
@@ -10,7 +10,7 @@ export function isComment(position: vscode.Position) {
     if (!document) {
         return;
     }
-    let line = document.lineAt(position.line).text.trim();
+    const line = document.lineAt(position.line).text.trim();
     // TODO make comment format for generic for all languages.
     if (!line.startsWith('*/') &&
         (line.startsWith('//') || line.startsWith('/**') || line.startsWith('*'))) {


### PR DESCRIPTION
Adds a inline code generation command that can be triggered with key stroke: Shift + Ctrl + Enter.

Can be used together with a single line comment:

```
// Prompt for code generation.
```